### PR TITLE
Project to EPSG:4326 when converting to GeoJSON

### DIFF
--- a/tiler/tiler-scripts/postgis2geojson.py
+++ b/tiler/tiler-scripts/postgis2geojson.py
@@ -22,7 +22,7 @@ def postgis2geojson(TABLE_NAME, DATABASE_VARS, LAYER_CONFIG=False, QUERY=False):
     except OSError:
         pass
 
-    connect_command = """ogr2ogr -f GeoJSON {} PG:"host={} port={} user={} dbname={} password={}" -sql "{}" """.format(
+    connect_command = """ogr2ogr -f GeoJSON {} -t_srs EPSG:4326 PG:"host={} port={} user={} dbname={} password={}" -sql "{}" """.format(
         OUTPUT_PATH,
         DATABASE_VARS['DB_HOST'],
         DATABASE_VARS['DB_PORT'],

--- a/tiler/tiler-scripts/shapefile2geojson.py
+++ b/tiler/tiler-scripts/shapefile2geojson.py
@@ -22,7 +22,8 @@ def shapefile2geojson(INPUT_PATH, OUTPUT_NAME, LAYER_CONFIG=False):
         pass
 
     try:
-        connect_command = """ogr2ogr -f GeoJSON {} {}""".format(OUTPUT_PATH, INPUT_PATH)
+        connect_command = """ogr2ogr -f GeoJSON -t_srs EPSG:4326 {} {}""".format(OUTPUT_PATH,
+                                                                                 INPUT_PATH)
         print "\n Executing: ", connect_command
         process = subprocess.Popen(connect_command, shell=True)
 
@@ -53,4 +54,4 @@ if __name__ == '__main__':
         raise  ValueError("OUTPUT_NAME not defined" )
     
     shapefile2geojson(INPUT_PATH, OUTPUT_NAME)
-    
+


### PR DESCRIPTION
While making tiles from a shapefile that's in a UTM projection, I got this error:
```
For layer 0, using name "neighborhoodwaysgeojson"
/tiler-data/geojson/neighborhoodways.geojson: Warning: GeoJSON specified projection "urn:ogc:def:crs:EPSG::32$
18", not "urn:ogc:def:crs:OGC:1.3:CRS84".
1534 features, 122855 bytes of geometry, 4 bytes of separate metadata, 83267 bytes of string pool
  2.7%  0/0/0  

More than half the features were clipped away at zoom level 0.
Is your data in the wrong projection? It should be in WGS84/EPSG:4326.
```

Adds `-t_srs EPSG:4326` to the ogr2ogr commands.